### PR TITLE
Pass table name to extension functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ class PgAnonymizer extends Command {
       };
     });
 
-    let table = null;
+    let table: string | null = null;
     let indices: Number[] = [];
     let cols: string[] = [];
 
@@ -150,7 +150,7 @@ class PgAnonymizer extends Command {
                       return acc[key];
                     }
                     return acc;
-                  }, extension)(v);
+                  }, extension)(v, table);
                 }
                 return replacement;
               }


### PR DESCRIPTION
I have a use case where multiple tables have a `name` field, but only one of them refers to PII that needs to be scrubbed, while the other tables should remain intact.

Currently there's no way to disambiguate which table we're working with. This PR would pass the table name as an additional argument to extension functions so that they can make smarter decisions about how/if to anonymize.

Open to other ideas here; I figured this way wouldn't cause any breaking changes.