### PR TITLE
feat: add support to specify tables in list of columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Specifying another list via `--list` replace the default automatically anonymize
 email,name,description,address,city,country,phone,comment,birthdate
 ```
 
-You can also specify the table for a column using the slash notation:
+You can also specify the table for a column using the dot notation:
 
 ```csv
-public.user/email,public.product/description
+public.user.email,public.product.description,email,name
 ```
 
 #### Customize replacements 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Specifying another list via `--list` replace the default automatically anonymize
 email,name,description,address,city,country,phone,comment,birthdate
 ```
 
+You can also specify the table for a column using the slash notation:
+
+```csv
+public.user/email,public.product/description
+```
+
 #### Customize replacements 
 
 You can also choose which faker function you want to use to replace data (default is `faker.random.word`):
@@ -69,10 +75,6 @@ module.exports = {
   }
 };
 ```
-
-### Memory limit
-
-Use `-m` to change `pg_dump` output memory limit (e.g: `512`)
 
 ### Locale (i18n)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,8 @@ class PgAnonymizer extends Command {
           .map((e) => e.toLowerCase());
 
         indices = cols.reduce((acc: Number[], value, key) => {
-          if (list.find((l) => l.col === value)) acc.push(key);
+          if (list.find((l) => l.col === value)) acc.push(key)
+          else if (list.find((l) => l.col === table + '/' + value)) acc.push(key);
           return acc;
         }, []);
 
@@ -127,9 +128,14 @@ class PgAnonymizer extends Command {
           .split("\t")
           .map((v, k) => {
             if (indices.includes(k)) {
-              const replacement = list.find(
+              let replacement = list.find(
                 (l) => l.col === cols[k]
               )?.replacement;
+              if (!replacement) {
+                replacement = list.find(
+                  (l) => l.col === table + '/' + cols[k]
+                )?.replacement;
+              }
               if (replacement) {
                 if (replacement.startsWith("faker.")) {
                   const [_one, two, three] = replacement.split(".");
@@ -148,18 +154,19 @@ class PgAnonymizer extends Command {
                   }, extension)(v, table);
                 }
                 return replacement;
+              } else {
+                if (cols[k] === "email") return faker.internet.email();
+                if (cols[k] === "name") return faker.name.findName();
+                if (cols[k] === "description") return faker.random.words(3);
+                if (cols[k] === "address") return faker.address.streetAddress();
+                if (cols[k] === "city") return faker.address.city();
+                if (cols[k] === "country") return faker.address.country();
+                if (cols[k] === "phone") return faker.phone.phoneNumber();
+                if (cols[k] === "comment") return faker.random.words(3);
+                if (cols[k] === "birthdate")
+                  return postgreSQLDate(faker.date.past());
+                return faker.random.word();
               }
-              if (cols[k] === "email") return faker.internet.email();
-              if (cols[k] === "name") return faker.name.findName();
-              if (cols[k] === "description") return faker.random.words(3);
-              if (cols[k] === "address") return faker.address.streetAddress();
-              if (cols[k] === "city") return faker.address.city();
-              if (cols[k] === "country") return faker.address.country();
-              if (cols[k] === "phone") return faker.phone.phoneNumber();
-              if (cols[k] === "comment") return faker.random.words(3);
-              if (cols[k] === "birthdate")
-                return postgreSQLDate(faker.date.past());
-              return faker.random.word();
             }
             return v;
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,8 @@ class PgAnonymizer extends Command {
     }),
     pgDumpOutputMemory: flags.string({
       char: "m",
-      description: "max memory used to get output from pg_dump in MB",
-      default: "256",
+      description: "Obsolete, not needed any more: max memory used to get output from pg_dump in MB",
+      default: "0",
     }),
   };
 
@@ -113,7 +113,7 @@ class PgAnonymizer extends Command {
 
         indices = cols.reduce((acc: Number[], value, key) => {
           if (list.find((l) => l.col === value)) acc.push(key)
-          else if (list.find((l) => l.col === table + '/' + value)) acc.push(key);
+          else if (list.find((l) => l.col === table + '.' + value)) acc.push(key);
           return acc;
         }, []);
 
@@ -133,7 +133,7 @@ class PgAnonymizer extends Command {
               )?.replacement;
               if (!replacement) {
                 replacement = list.find(
-                  (l) => l.col === table + '/' + cols[k]
+                  (l) => l.col === table + '.' + cols[k]
                 )?.replacement;
               }
               if (replacement) {
@@ -154,19 +154,18 @@ class PgAnonymizer extends Command {
                   }, extension)(v, table);
                 }
                 return replacement;
-              } else {
-                if (cols[k] === "email") return faker.internet.email();
-                if (cols[k] === "name") return faker.name.findName();
-                if (cols[k] === "description") return faker.random.words(3);
-                if (cols[k] === "address") return faker.address.streetAddress();
-                if (cols[k] === "city") return faker.address.city();
-                if (cols[k] === "country") return faker.address.country();
-                if (cols[k] === "phone") return faker.phone.phoneNumber();
-                if (cols[k] === "comment") return faker.random.words(3);
-                if (cols[k] === "birthdate")
-                  return postgreSQLDate(faker.date.past());
-                return faker.random.word();
               }
+              if (cols[k] === "email") return faker.internet.email();
+              if (cols[k] === "name") return faker.name.findName();
+              if (cols[k] === "description") return faker.random.words(3);
+              if (cols[k] === "address") return faker.address.streetAddress();
+              if (cols[k] === "city") return faker.address.city();
+              if (cols[k] === "country") return faker.address.country();
+              if (cols[k] === "phone") return faker.phone.phoneNumber();
+              if (cols[k] === "comment") return faker.random.words(3);
+              if (cols[k] === "birthdate")
+                return postgreSQLDate(faker.date.past());
+              return faker.random.word();
             }
             return v;
           })


### PR DESCRIPTION
Now you can replace columns in a specifiic table instead of all tables that have the same column name. You can also specify different replacements for the same column name in different table.

also fixed a bug where a static word replacement was overridden by faker.random.word.

Merry Christmas!