### PR TITLE
Escape postgresql key words in table names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,9 @@ class PgAnonymizer extends Command {
 
     for await (let line of inputLineResults) {
       if (line.match(/^COPY .* FROM stdin;$/)) {
-        table = line.replace(/^COPY (.*?) .*$/, "$1");
+        table = line
+          .replace(/^COPY (.*?) .*$/, "$1")
+          .replace(/"/g, "");
         console.error("Anonymizing table " + table);
 
         cols = line


### PR DESCRIPTION
When the table in postgresql is named after postgres keywords (i.e. user) in order to escape those keywords they are used with quotes (user -> "user"). Because of that, the anonymization process do not properly match the table names that are being provided by command-line argument with available tables from the database. To fix that I added one more step when extracting table names form SQL that removes optional quotes so the table names are matched even for the postgres keywords. The resulting anonymized SQL script will still have proper table names with quotes as table name that this fix affects is only used for potential anonymization method matching. 